### PR TITLE
docs: add README video embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ ClientClub Downloader is a browser extension built for users who want a simpler 
 - Choose from the quality levels exposed by the source
 - Keep local copies for offline study, review, or coaching archives
 
+## Watch The Video
+
+<a href="https://www.youtube.com/watch?v=zY7GIt0dlLc" target="_blank">
+<img src="https://raw.githubusercontent.com/devinschumacher/uploads/refs/heads/main/images/how-to-download-clientclub-videos.jpg" width="700px">
+</a>
+
 ## Links
 
 - :rocket: Get it here: [ClientClub Downloader](https://serp.ly/clientclub-downloader)
@@ -20,7 +26,7 @@ ClientClub Downloader is a browser extension built for users who want a simpler 
 
 ## Preview
 
-![ClientClub Downloader workflow preview](assets/workflow-preview.webp)
+![ClientClub Downloader workflow preview](https://raw.githubusercontent.com/serpapps/clientclub-downloader/refs/heads/main/assets/workflow-preview.webp)
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ ClientClub Downloader is a browser extension built for users who want a simpler 
 - Choose from the quality levels exposed by the source
 - Keep local copies for offline study, review, or coaching archives
 
-## Watch The Video
-
-<a href="https://www.youtube.com/watch?v=zY7GIt0dlLc" target="_blank">
-<img src="https://raw.githubusercontent.com/devinschumacher/uploads/refs/heads/main/images/how-to-download-clientclub-videos.jpg" width="700px">
-</a>
-
 ## Links
 
 - :rocket: Get it here: [ClientClub Downloader](https://serp.ly/clientclub-downloader)
@@ -26,7 +20,9 @@ ClientClub Downloader is a browser extension built for users who want a simpler 
 
 ## Preview
 
-![ClientClub Downloader workflow preview](https://raw.githubusercontent.com/serpapps/clientclub-downloader/refs/heads/main/assets/workflow-preview.webp)
+<a href="https://www.youtube.com/watch?v=zY7GIt0dlLc" target="_blank">
+<img src="https://raw.githubusercontent.com/devinschumacher/uploads/refs/heads/main/images/how-to-download-clientclub-videos.jpg" width="700px">
+</a>
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary
- Adds the Watch The Video README section from the reviewed dry-run file
- Converts local README image references to raw GitHub URLs where applicable

## Notes
- This PR was created from the local dry-run README preview.
- No force push was used.
